### PR TITLE
Fix Command "dumpautoload;" is not defined.

### DIFF
--- a/src/Commands/Install/FjordInstall.php
+++ b/src/Commands/Install/FjordInstall.php
@@ -163,7 +163,7 @@ class FjordInstall extends Command
         $composer = json_decode(File::get(base_path('composer.json')), true);
         $composer['autoload']['psr-4']['FjordApp\\'] = 'fjord/app/';
         File::put(base_path('composer.json'), json_encode($composer, JSON_PRETTY_PRINT));
-        shell_exec('composer dumpautoload;');
+        shell_exec('composer dumpautoload');
     }
 
     /**


### PR DESCRIPTION
## Changes:
* Remove `;` from `composer dumpautoload;`

## Issues:
* [Command "dumpautoload;" is not defined.](https://github.com/aw-studio/fjord/issues/12)