### PR TITLE
Fix naming convention

### DIFF
--- a/src/Commands/FjordForm.php
+++ b/src/Commands/FjordForm.php
@@ -59,7 +59,7 @@ class FjordForm extends Command
         $controller->withPermission("{$collection}");
         $controller->withConfigClass($controllerName . "Config");
 
-        $configDir = base_path("fjord/app/Config/Form/{$collection}");
+        $configDir = base_path("fjord/app/Config/Form/{$controllerNamespace}");
         $config = new StubBuilder(fjord_path('stubs/FormConfig.stub'));
         $config->withCollection($controllerNamespace);
         $config->withFormName("'" . lcfirst($formName) . "'");


### PR DESCRIPTION
Creating a form via FjordForm leads to an error. Creating the collection folder with a leading uppercase solves the problem.