### PR TITLE
Fix Laravel typo

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -8,7 +8,7 @@ An existing Laravel project is required to install Fjord as well as a database c
 
 ## Requirements
 
-Fjord requires **PHP 7.4+** and **Larvel 7+**. As well as all [requirements](https://docs.spatie.be/laravel-medialibrary/v8/requirements) of **spatie/laravel-medialibrary 8.2+**.
+Fjord requires **PHP 7.4+** and **Laravel 7+**. As well as all [requirements](https://docs.spatie.be/laravel-medialibrary/v8/requirements) of **spatie/laravel-medialibrary 8.2+**.
 
 ## Installing Fjord
 


### PR DESCRIPTION
There was a typo on [this page](https://www.fjord-admin.com/docs/getting-started/installation/#setup), just wanted to submit a quick fix.