### PR TITLE
Add composer v2 compatibility

### DIFF
--- a/src/Fjord/Discover/PackageDiscoverCommand.php
+++ b/src/Fjord/Discover/PackageDiscoverCommand.php
@@ -84,7 +84,7 @@ class PackageDiscoverCommand extends LaravelPackageDiscoverCommand
     public function filterFjordPackages(array $packages)
     {
         // Filter for packages containing "extra": {"fjord": ...}.
-        return collect($packages)->mapWithKeys(function ($package) {
+        return collect($packages['packages'] ?? $packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['fjord'] ?? []];
         })->filter()->all();
     }


### PR DESCRIPTION
As mentioned in #31 composer's v2 is in alpha, but the fix seems simple, add compatibility with 2.x meanwhile maintains retrocompatibility with 1.x